### PR TITLE
ci(actions): added pr template for creating descriptive prs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description
+
+Please include a summary of the changes and the related issue. Highlight any key details that are important for reviewers to know.
+
+- **Related issue:** [Insert issue number or link here]
+
+## Type of Change
+
+Please delete options that are not relevant:
+
+- 🐛 Bug fix (non-breaking change that fixes an issue)
+- ✨ New feature, style (non-breaking change that adds functionality)
+- ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- 📄 Documentation changes (if none of the above apply)
+- 🔧 Refactor, perf, test, build, fix
+- 🧹 Chore, CI, Revert
+
+## Checklist
+
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas (if necessary)
+- [ ] I have updated the documentation (if necessary)
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing tests pass locally with my changes
+
+## Screenshots (if applicable)
+
+If your changes include visual updates or involve the frontend, please include relevant screenshots to showcase your work.
+
+## Further Comments
+
+Add any additional comments or context here.


### PR DESCRIPTION
## Description

Created a simple PR template to describe our changes. The template is stored in the .github folder in the root.

    Related issue: [not ready]

## Type of Change

Please delete options that are not relevant:

- 🧹 Chore, CI, Revert

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (if necessary)
- [ ] I have updated the documentation (if necessary)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Screenshots (if applicable)

If your changes include visual updates or involve the frontend, please include relevant screenshots to showcase your work.

## Further Comments

Add any additional comments or context here.