### PR TITLE
Hero and button styling

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -12,7 +12,7 @@ const Button: React.FC<ButtonProps> = ({ label, onClick, buttonType }) => {
       onClick={onClick}
       className={
         buttonType === "cardButton"
-          ? "bg-buttonBg text-zubiText font-helonik py-2 px-4 rounded-full transition duration-300 ease-in-out hover:bg-zubiLogo"
+          ? "bg-buttonBg text-zubiText font-helonik py-3 px-11  text-lg rounded-full transition duration-300 ease-in-out hover:bg-zubiLogo"
           : "bg-buttonBg text-zubiText font-helonik py-4 px-6 text-xl rounded-full transition duration-300 ease-in-out hover:bg-zubiLogo"
       }
       style={{ margin: "2px" }}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,6 +3,7 @@ import React from "react";
 interface ButtonProps {
   label: string;
   onClick: () => void;
+  buttonType: string;
 }
 
 const Button: React.FC<ButtonProps> = ({ label, onClick, buttonType }) => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -13,7 +13,7 @@ const Button: React.FC<ButtonProps> = ({ label, onClick, buttonType }) => {
       className={
         buttonType === "cardButton"
           ? "bg-buttonBg text-zubiText font-helonik py-2 px-4 rounded-full transition duration-300 ease-in-out hover:bg-zubiLogo"
-          : "bg-buttonBg"
+          : "bg-buttonBg text-zubiText font-helonik py-4 px-6 text-xl rounded-full transition duration-300 ease-in-out hover:bg-zubiLogo"
       }
       style={{ margin: "2px" }}
     >

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,16 +1,20 @@
-import React from 'react';
+import React from "react";
 
 interface ButtonProps {
   label: string;
-  onClick: () => void; 
+  onClick: () => void;
 }
 
-const Button: React.FC<ButtonProps> = ({ label, onClick }) => {
+const Button: React.FC<ButtonProps> = ({ label, onClick, buttonType }) => {
   return (
     <button
       onClick={onClick}
-      className="bg-buttonBg text-zubiText font-helonik py-2 px-4 rounded-full transition duration-300 ease-in-out hover:bg-zubiLogo"
-      style={{ margin: '2px' }}
+      className={
+        buttonType === "cardButton"
+          ? "bg-buttonBg text-zubiText font-helonik py-2 px-4 rounded-full transition duration-300 ease-in-out hover:bg-zubiLogo"
+          : "bg-buttonBg"
+      }
+      style={{ margin: "2px" }}
     >
       {label}
     </button>

--- a/src/components/CardsContainer/Card/Card.tsx
+++ b/src/components/CardsContainer/Card/Card.tsx
@@ -1,3 +1,5 @@
+import Button from "../../Button/Button";
+
 interface Tutor {
   id: number;
   full_name: string;
@@ -23,9 +25,7 @@ const Card = ({ tutor }: CardProps) => {
       <h3 className="text-2xl">{tutor.full_name}</h3>
       <img src={tutor.img_source} className="h-44 w-64 bg-white rounded-md" />
       <p className="font-sans leading-5">{tutor.description}</p>
-      <button className="bg-white text-zubiText py-4 px-9 rounded-full text-xl">
-        learn from me
-      </button>
+      <Button label="learn with me" buttonType="cardButton" />
     </div>
   );
 };

--- a/src/components/CardsContainer/Card/Card.tsx
+++ b/src/components/CardsContainer/Card/Card.tsx
@@ -25,7 +25,11 @@ const Card = ({ tutor }: CardProps) => {
       <h3 className="text-2xl">{tutor.full_name}</h3>
       <img src={tutor.img_source} className="h-44 w-64 bg-white rounded-md" />
       <p className="font-sans leading-5">{tutor.description}</p>
-      <Button label="learn with me" buttonType="cardButton" />
+      <Button
+        onClick={() => console.log("card button clicked")}
+        label="learn with me"
+        buttonType="cardButton"
+      />
     </div>
   );
 };

--- a/src/components/CardsContainer/Card/Card.tsx
+++ b/src/components/CardsContainer/Card/Card.tsx
@@ -21,7 +21,7 @@ interface CardProps {
 
 const Card = ({ tutor }: CardProps) => {
   return (
-    <div className="mb-16 p-8 rounded-md font-helonik tutor-card bg-zubiGreen w-3/4 m-auto text-white flex flex-col gap-7">
+    <div className="mb-16 p-8 rounded-md font-helonik tutor-card bg-zubiGreen w-10/12 m-auto text-white flex flex-col items-center gap-7">
       <h3 className="text-2xl">{tutor.full_name}</h3>
       <img src={tutor.img_source} className="h-44 w-64 bg-white rounded-md" />
       <p className="font-sans leading-5">{tutor.description}</p>

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -8,7 +8,11 @@ function HeroSection() {
         <Logo className="w-32" />
         <h1 className="text-8xl text-center">zubi</h1>
         <p className="text-center mt-4 text-2xl">Bridge your skills</p>
-        <Button label="get started" buttonType="cardButton" />
+        <Button
+          onClick={() => console.log("hero button clicked")}
+          label="get started"
+          buttonType=""
+        />
       </div>
     </div>
   );

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -5,7 +5,7 @@ function HeroSection() {
   return (
     <div className="h-screen mt-16 bg-zubiGreen flex flexcol justify-center content-center font-helonik text-white">
       <div className="hero-content flex flex-col items-center mt-44">
-        <Logo className="w-32" />
+        <Logo className="w-28" />
         <h1 className="text-8xl text-center">zubi</h1>
         <p className="text-center mt-4 mb-16 text-2xl">Bridge your skills</p>
         <Button

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -4,10 +4,10 @@ import Button from "../Button/Button";
 function HeroSection() {
   return (
     <div className="h-screen mt-16 bg-zubiGreen flex flexcol justify-center content-center font-helonik text-white">
-      <div className="hero-content flex flex-col items-center gap-6 mt-44">
+      <div className="hero-content flex flex-col items-center mt-44">
         <Logo className="w-32" />
         <h1 className="text-8xl text-center">zubi</h1>
-        <p className="text-center mt-4 text-2xl">Bridge your skills</p>
+        <p className="text-center mt-4 mb-16 text-2xl">Bridge your skills</p>
         <Button
           onClick={() => console.log("hero button clicked")}
           label="get started"

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,4 +1,5 @@
 import Logo from "../Logo/Logo";
+import Button from "../Button/Button";
 
 function HeroSection() {
   return (
@@ -7,6 +8,7 @@ function HeroSection() {
         <Logo className="w-32" />
         <h1 className="text-8xl text-center">zubi</h1>
         <p className="text-center mt-4 text-2xl">Bridge your skills</p>
+        <Button label="get started" buttonType="cardButton" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

- Added conditional rendering to the button element (needs to be refactored but works for now)
- Changed margins and Logo size in hero section to look more like Figma design
- Added onClick placeholders for buttons that have been rendered
- Increase width of cards in mobile display

<img width="1018" alt="Screenshot 2024-10-16 at 17 51 12" src="https://github.com/user-attachments/assets/660a17bf-e9f2-4e17-827c-93c890edf9ba">
<img width="508" alt="Screenshot 2024-10-16 at 17 51 03" src="https://github.com/user-attachments/assets/f92be873-ab2e-40cd-b5c9-4547c2f293ca">
